### PR TITLE
Sindragosa: modernize and optimize code

### DIFF
--- a/DBM-Icecrown/FrostwingHalls/Sindragosa.lua
+++ b/DBM-Icecrown/FrostwingHalls/Sindragosa.lua
@@ -1,19 +1,19 @@
 local mod	= DBM:NewMod("Sindragosa", "DBM-Icecrown", 4)
 local L		= mod:GetLocalizedStrings()
 
-mod:SetRevision("20220518110528")
+mod:SetRevision("20220624005857")
 mod:SetCreatureID(36853)
-mod:SetUsedIcons(3, 4, 5, 6, 7, 8)
-mod:SetMinSyncRevision(3712)
+mod:SetUsedIcons(1, 2, 3, 4, 5, 6)
+mod:SetMinSyncRevision(20220623000000)
 
 mod:RegisterCombat("combat")
 
 mod:RegisterEventsInCombat(
 	"SPELL_CAST_START 69649 71056 71057 71058 73061 73062 73063 73064 71077",
+	"SPELL_CAST_SUCCESS 70117",
 	"SPELL_AURA_APPLIED 70126 69762 70106 69766 70127 72528 72529 72530",
 	"SPELL_AURA_APPLIED_DOSE 70106 69766 70127 72528 72529 72530",
-	"SPELL_AURA_REMOVED 69762 70157 70126 70106 69766 70127 72528 72529 72530",
-	"SPELL_CAST_SUCCESS 70117",
+	"SPELL_AURA_REMOVED 69762 70157 70106 69766 70127 72528 72529 72530",
 	"UNIT_HEALTH boss1",
 	"CHAT_MSG_MONSTER_YELL"
 )
@@ -25,7 +25,7 @@ local myRealm = select(3, DBM:GetMyPlayerInfo())
 local berserkTimer				= mod:NewBerserkTimer((myRealm == "Lordaeron" or myRealm == "Frostmourne") and 420 or 600)
 
 mod:AddBoolOption("RangeFrame", true) -- keep as BoolOption since the localization offers important information regarding boss ability and player debuff behaviour
-mod:AddBoolOption("ClearIconsOnAirphase", true)
+mod:AddBoolOption("ClearIconsOnAirphase", true) -- don't group with any spellId, it applies to all raid icons
 
 -- Stage One
 mod:AddTimerLine(DBM_CORE_L.SCENARIO_STAGE:format(1))
@@ -34,7 +34,7 @@ local warnGroundphaseSoon		= mod:NewAnnounce("WarnGroundphaseSoon", 2, 43810)
 local warnPhase2soon			= mod:NewPrePhaseAnnounce(2)
 local warnInstability			= mod:NewCountAnnounce(69766, 2, nil, false)
 local warnChilledtotheBone		= mod:NewCountAnnounce(70106, 2, nil, false)
-local warnFrostBeacon			= mod:NewTargetAnnounce(70126, 4)
+local warnFrostBeacon			= mod:NewTargetNoFilterAnnounce(70126, 4)
 local warnFrostBreath			= mod:NewSpellAnnounce(69649, 2, nil, "Tank|Healer")
 local warnUnchainedMagic		= mod:NewTargetAnnounce(69762, 2, nil, "SpellCaster", 2)
 
@@ -58,9 +58,9 @@ local timerTailSmash			= mod:NewCDTimer(30, 71077, nil, nil, nil, 2) -- random t
 
 local soundUnchainedMagic		= mod:NewSoundYou(69762, nil, "SpellCaster")
 
-mod:AddSetIconOption("SetIconOnFrostBeacon", 70126, true, false, {3, 4, 5, 6, 7, 8})
-mod:AddSetIconOption("SetIconOnUnchainedMagic", 69762, true, false, {2, 3, 4, 5, 6, 7})
-mod:AddBoolOption("AnnounceFrostBeaconIcons", false, "announce", nil, nil, nil, 70126)
+mod:AddSetIconOption("SetIconOnFrostBeacon", 70126, true, 7, {1, 2, 3, 4, 5, 6})
+mod:AddSetIconOption("SetIconOnUnchainedMagic", 69762, true, 0, {1, 2, 3, 4, 5, 6})
+mod:AddBoolOption("AnnounceFrostBeaconIcons", false, nil, nil, nil, nil, 70126)
 mod:AddBoolOption("AssignWarnDirectionsCount", true, nil, nil, nil, nil, 70126)
 
 -- Stage Two
@@ -77,80 +77,59 @@ local timerMysticAchieve		= mod:NewAchievementTimer(30, 4620, "AchievementMystic
 mod:AddBoolOption("AchievementCheck", false, "announce", nil, nil, nil, 4620, "achievement")
 
 local beaconTargets		= {}
-local beaconIconTargets	= {}
 local unchainedTargets	= {}
 mod.vb.warned_P2 = false
 mod.vb.warnedfailed = false
-mod.vb.unchainedIcons = 7
-mod.vb.activeBeacons	= false
-local p2_beacon_num = 1
+mod.vb.unchainedIcons = 1
+mod.vb.beaconP2Count = 1
 local playerUnchained = false
 local playerBeaconed = false
-local beaconDebuff, unchainedDebuff = DBM:GetSpellInfo(70126), DBM:GetSpellInfo(69762)
 
 local directionIndex
-local DirectionAssignments		= {DBM_COMMON_L.LEFT, DBM_COMMON_L.MIDDLE, DBM_COMMON_L.RIGHT}
+local DirectionAssignments = {DBM_COMMON_L.LEFT, DBM_COMMON_L.MIDDLE, DBM_COMMON_L.RIGHT}
 local DirectionVoiceAssignments	= {"left", "center", "right"}
 
-local function ClearBeaconTargets(self)
-	table.wipe(beaconIconTargets)
-	if self.Options.RangeFrame then
-		DBM.RangeCheck:Hide()
-	end
-end
-
+local beaconDebuffFilter, unchainedDebuffFilter
 do
-	-- local function sort_by_group(v1, v2)
-	-- 	return DBM:GetRaidSubgroup(DBM:GetUnitFullName(v1)) < DBM:GetRaidSubgroup(DBM:GetUnitFullName(v2))
-	-- end
-	function mod:SetBeaconIcons()
-		table.sort(beaconIconTargets, function(v1,v2) return DBM:GetRaidSubgroup(v1) < DBM:GetRaidSubgroup(v2) end)
-		local beaconIcons = 8
-		for _, v in ipairs(beaconIconTargets) do
-			if self.Options.AnnounceFrostBeaconIcons and DBM:GetRaidRank() > 0 then
-				SendChatMessage(L.BeaconIconSet:format(beaconIcons, DBM:GetUnitFullName(v)), "RAID")
-			end
-			self:SetIcon(v, beaconIcons)
-			beaconIcons = beaconIcons - 1
-		end
-		self:Schedule(8, ClearBeaconTargets, self)
-	end
-end
-
-local beaconDebuffFilter
-do
+	local beaconDebuff, unchainedDebuff = DBM:GetSpellInfo(70126), DBM:GetSpellInfo(69762)
 	beaconDebuffFilter = function(uId)
 		return DBM:UnitDebuff(uId, beaconDebuff)
+	end
+	unchainedDebuffFilter = function(uId)
+		return DBM:UnitDebuff(uId, unchainedDebuff)
 	end
 end
 
 local function warnBeaconTargets(self)
 	if self.Options.RangeFrame then
 		if not playerBeaconed then
-			DBM.RangeCheck:Show(10, beaconDebuffFilter)
+			DBM.RangeCheck:Show(10, beaconDebuffFilter, nil, nil, nil, 9)
 		else
-			DBM.RangeCheck:Show(10)
+			DBM.RangeCheck:Show(10, nil, nil, nil, nil, 9)
 		end
 	end
 	if self.Options.AssignWarnDirectionsCount then
 		if self.vb.phase == 1 then
 			if self:IsDifficulty("normal25") then
+				-- 5 beacons
 				warnFrostBeacon:Show("\n<   >"..
-				strupper(DBM_COMMON_L.LEFT)	..": <".."   >"..(beaconTargets[1] or DBM_COMMON_L.UNKNOWN).."<, >"..(beaconTargets[2] or DBM_COMMON_L.UNKNOWN).."<   >\n".."<   >"..
+				strupper(DBM_COMMON_L.LEFT)		..": <".."   >"..(beaconTargets[1] or DBM_COMMON_L.UNKNOWN).."<, >"..(beaconTargets[2] or DBM_COMMON_L.UNKNOWN).."<   >\n".."<   >"..
 				strupper(DBM_COMMON_L.MIDDLE)	..": <".."   >"..(beaconTargets[3] or DBM_COMMON_L.UNKNOWN).."<   >\n".."<   >"..
 				strupper(DBM_COMMON_L.RIGHT)	..": <".."   >"..(beaconTargets[4] or DBM_COMMON_L.UNKNOWN).."<, >"..(beaconTargets[5] or DBM_COMMON_L.UNKNOWN))
 			elseif self:IsDifficulty("heroic25") then
+				-- 6 beacons
 				warnFrostBeacon:Show("\n<   >"..
-				strupper(DBM_COMMON_L.LEFT)	..": <".."   >"..(beaconTargets[1] or DBM_COMMON_L.UNKNOWN).."<, >"..(beaconTargets[2] or DBM_COMMON_L.UNKNOWN).."<   >\n".."<   >"..
+				strupper(DBM_COMMON_L.LEFT)		..": <".."   >"..(beaconTargets[1] or DBM_COMMON_L.UNKNOWN).."<, >"..(beaconTargets[2] or DBM_COMMON_L.UNKNOWN).."<   >\n".."<   >"..
 				strupper(DBM_COMMON_L.MIDDLE)	..": <".."   >"..(beaconTargets[3] or DBM_COMMON_L.UNKNOWN).."<, >"..(beaconTargets[4] or DBM_COMMON_L.UNKNOWN).."<   >\n".."<   >"..
 				strupper(DBM_COMMON_L.RIGHT)	..": <".."   >"..(beaconTargets[5] or DBM_COMMON_L.UNKNOWN).."<, >"..(beaconTargets[6] or DBM_COMMON_L.UNKNOWN))
 			elseif self:IsDifficulty("normal10", "heroic10") then
+				-- 2 beacons
 				warnFrostBeacon:Show("\n<   >"..
-				strupper(DBM_COMMON_L.LEFT)	..": <".."   >"..(beaconTargets[1] or DBM_COMMON_L.UNKNOWN).."<   >\n".."<   >"..
+				strupper(DBM_COMMON_L.LEFT)		..": <".."   >"..(beaconTargets[1] or DBM_COMMON_L.UNKNOWN).."<   >\n".."<   >"..
 				strupper(DBM_COMMON_L.RIGHT)	..": <".."   >"..(beaconTargets[2] or DBM_COMMON_L.UNKNOWN))
 			end
 		elseif self.vb.phase == 2 then
-			warnFrostBeacon:Show(beaconTargets[1].."< = >"..p2_beacon_num-1)
+			warnFrostBeacon:Show(beaconTargets[1].."< = >"..self.vb.beaconP2Count - 1)
 		end
 	else
 		warnFrostBeacon:Show(table.concat(beaconTargets, "<, >"))
@@ -159,25 +138,18 @@ local function warnBeaconTargets(self)
 	playerBeaconed = false
 end
 
-local unchainedDebuffFilter
-do
-	unchainedDebuffFilter = function(uId)
-		return DBM:UnitDebuff(uId, unchainedDebuff)
-	end
-end
-
 local function warnUnchainedTargets(self)
 	if self.Options.RangeFrame then
 		if not playerUnchained then
 			DBM.RangeCheck:Show(21, unchainedDebuffFilter) -- 21.5 yd with new radar calculations. 21 here since radar code adds 0.5 to activeRange
 		else
-			DBM.RangeCheck:Show(21)	-- 21.5 yd with new radar calculations. 21 here since radar code adds 0.5 to activeRange(это еще хз конечно как на сирусе)
+			DBM.RangeCheck:Show(21) -- 21.5 yd with new radar calculations. 21 here since radar code adds 0.5 to activeRange
 		end
 	end
 	warnUnchainedMagic:Show(table.concat(unchainedTargets, "<, >"))
 	timerUnchainedMagic:Start()
 	table.wipe(unchainedTargets)
-	self.vb.unchainedIcons = 7
+	self.vb.unchainedIcons = 1
 	playerUnchained = false
 end
 
@@ -205,7 +177,13 @@ local function ResetRange(self)
 		DBM.RangeCheck:DisableBossMode()
 	end
 end
--- mod:SetStage(0)
+
+function mod:AnnounceBeaconIcons(uId, icon)
+	if self.Options.AnnounceFrostBeaconIcons and IsInGroup() and DBM:GetRaidRank() > 1 then
+		SendChatMessage(L.BeaconIconSet:format(icon, DBM:GetUnitFullName(uId)), IsInRaid() and "RAID" or "PARTY")
+	end
+end
+
 function mod:OnCombatStart(delay)
 	self:SetStage(1)
 	berserkTimer:Start(-delay)
@@ -215,13 +193,11 @@ function mod:OnCombatStart(delay)
 	self.vb.warned_P2 = false
 	self.vb.warnedfailed = false
 	table.wipe(beaconTargets)
-	table.wipe(beaconIconTargets)
 	table.wipe(unchainedTargets)
-	self.vb.unchainedIcons = 7
-	p2_beacon_num = 1
+	self.vb.unchainedIcons = 1
+	self.vb.beaconP2Count = 1
 	playerUnchained = false
 	playerBeaconed = false
-	self.vb.activeBeacons = false
 end
 
 function mod:OnCombatEnd()
@@ -235,7 +211,22 @@ function mod:SPELL_CAST_START(args)
 		warnFrostBreath:Show()
 		timerNextFrostBreath:Start()
 	elseif args.spellId == 71077 then
-	    timerTailSmash:Start()
+		timerTailSmash:Start()
+	end
+end
+
+function mod:SPELL_CAST_SUCCESS(args)
+	local spellId = args.spellId
+	if spellId == 70117 then--Icy Grip Cast, not blistering cold, but adds an extra 1sec to the warning
+		specWarnBlisteringCold:Show()
+		specWarnBlisteringCold:Play("runout")
+		timerBlisteringCold:Start()
+		timerNextBlisteringCold:Start()
+
+		if self.Options.RangeFrame then
+			DBM.RangeCheck:SetBossRange(25, self:GetBossUnitByCreatureId(36853))
+			self:Schedule(5.5, ResetRange, self)
+		end
 	end
 end
 
@@ -258,32 +249,27 @@ function mod:SPELL_AURA_APPLIED(args)
 				specWarnFrostBeacon:Play("scatter")
 			end
 		end
-		if self.vb.phase == 1 and self.Options.SetIconOnFrostBeacon then
-			table.insert(beaconIconTargets, DBM:GetRaidUnitId(args.destName))
-			self:UnscheduleMethod("SetBeaconIcons")
-			if (self:IsDifficulty("normal25") and #beaconIconTargets >= 5) or (self:IsDifficulty("heroic25") and #beaconIconTargets >= 6) or (self:IsDifficulty("normal10", "heroic10") and #beaconIconTargets >= 2) then
-				self:SetBeaconIcons()--Sort and fire as early as possible once we have all targets.
-			else
-				if self:LatencyCheck() then--Icon sorting is still sensitive and should not be done by laggy members that don't have all targets.
-					self:ScheduleMethod(0.3, "SetBeaconIcons")
-				end
-			end
-		end
 		if self.vb.phase == 2 then--Phase 2 there is only one icon/beacon, don't use sorting method if we don't have to.
-			p2_beacon_num = p2_beacon_num + 1
-			timerNextBeacon:Start(16, p2_beacon_num)
+			self.vb.beaconP2Count = self.vb.beaconP2Count + 1
+			timerNextBeacon:Start(16, self.vb.beaconP2Count)
 			if self.Options.SetIconOnFrostBeacon then
 				self:SetIcon(args.destName, 8)
-				if self.Options.AnnounceFrostBeaconIcons then
-					SendChatMessage(L.BeaconIconSet:format(8, args.destName), "RAID")
+				if self.Options.AnnounceFrostBeaconIcons and IsInGroup() and DBM:GetRaidRank() > 1 then
+					SendChatMessage(L.BeaconIconSet:format(8, args.destName), IsInRaid() and "RAID" or "PARTY")
 				end
 			end
-		end
-		self:Unschedule(warnBeaconTargets)
-		if self.vb.phase == 2 or (self:IsDifficulty("normal25") and #beaconTargets >= 5) or (self:IsDifficulty("heroic25") and #beaconTargets >= 6) or (self:IsDifficulty("normal10", "heroic10") and #beaconTargets >= 2) then
 			warnBeaconTargets(self)
-		else
-			self:Schedule(0.3, warnBeaconTargets, self)
+		else--Phase 1 air phase, multiple beacons
+			local maxBeacon = self:IsDifficulty("heroic25") and 6 or self:IsDifficulty("normal25") and 5 or 2--Heroic 10 and normal 2 are both 2
+			if self.Options.SetIconOnFrostBeacon then
+				self:SetSortedIcon("roster", 0.3, args.destName, 1, maxBeacon, false, "AnnounceBeaconIcons")
+			end
+			self:Unschedule(warnBeaconTargets)
+			if #beaconTargets >= maxBeacon then
+				warnBeaconTargets(self)
+			else
+				self:Schedule(0.3, warnBeaconTargets, self)
+			end
 		end
 	elseif spellId == 69762 then
 		unchainedTargets[#unchainedTargets + 1] = args.destName
@@ -296,7 +282,7 @@ function mod:SPELL_AURA_APPLIED(args)
 		if self.Options.SetIconOnUnchainedMagic then
 			self:SetIcon(args.destName, self.vb.unchainedIcons)
 		end
-		self.vb.unchainedIcons = self.vb.unchainedIcons - 1
+		self.vb.unchainedIcons = self.vb.unchainedIcons + 1
 		self:Unschedule(warnUnchainedTargets)
 		if #unchainedTargets >= 6 then
 			warnUnchainedTargets(self)
@@ -354,15 +340,13 @@ mod.SPELL_AURA_APPLIED_DOSE = mod.SPELL_AURA_APPLIED
 function mod:SPELL_AURA_REMOVED(args)
 	local spellId = args.spellId
 	if spellId == 69762 then
-		if self.Options.SetIconOnUnchainedMagic and not self.vb.activeBeacons then
-			self:RemoveIcon(args.destName)
+		if self.Options.SetIconOnUnchainedMagic then
+			self:SetIcon(args.destName, 0)
 		end
 	elseif spellId == 70157 then
 		if self.Options.SetIconOnFrostBeacon then
-			self:RemoveIcon(args.destName)
+			self:SetIcon(args.destName, 0)
 		end
-	elseif spellId == 70126 then
-		self.vb.activeBeacons = false
 	elseif spellId == 70106 then	--Chilled to the bone (melee)
 		if args:IsPlayer() then
 			timerChilledtotheBone:Cancel()
@@ -375,21 +359,6 @@ function mod:SPELL_AURA_REMOVED(args)
 		if args:IsPlayer() then
 			timerMysticAchieve:Cancel()
 			timerMysticBuffet:Cancel()
-		end
-	end
-end
-
-function mod:SPELL_CAST_SUCCESS(args)
-	local spellId = args.spellId
-	if spellId == 70117 then--Icy Grip Cast, not blistering cold, but adds an extra 1sec to the warning
-		specWarnBlisteringCold:Show()
-		specWarnBlisteringCold:Play("runout")
-		timerBlisteringCold:Start()
-		timerNextBlisteringCold:Start()
-
-		if self.Options.RangeFrame then -- todo fxpw
-			-- DBM.RangeCheck:SetBossRange(25, self:GetBossUnitByCreatureId(36853))
-			-- self:Schedule(5.5, ResetRange, self)
 		end
 	end
 end
@@ -414,13 +383,11 @@ function mod:CHAT_MSG_MONSTER_YELL(msg)
 		timerNextGroundphase:Start()
 		timerTailSmash:Start(68) -- 2 logs from late 2021 with 68 seconds after airphase begin. Need more logs to validate
 		warnGroundphaseSoon:Schedule(37.5)
-		self.vb.activeBeacons = true
 	elseif (msg == L.YellPhase2 or msg:find(L.YellPhase2)) or (msg == L.YellPhase2Dem or msg:find(L.YellPhase2Dem)) then
 		self:SetStage(2)
 		warnPhase2:Show()
 		warnPhase2:Play("ptwo")
-		p2_beacon_num = 1
-		timerNextBeacon:Start(7, p2_beacon_num)
+		timerNextBeacon:Start(7, 1) -- no need to use self.vb.beaconP2Count here since it will always be one on this timer
 		timerNextAirphase:Cancel()
 		timerNextGroundphase:Cancel()
 		warnGroundphaseSoon:Cancel()


### PR DESCRIPTION
- Updated to use more modern features;
- Changed several icons used to prefer lower index over higher index. Modern mods favor lower index so skull and X aren't used if they don't have to be (thus allowing raid leaders to actually use them for marking kill targets). Legacy mods tended to favor using those icons and it just doesn't align with current mod design.
- Changed beacon target warning to be non filtered target warnings since it was deemed important and it didn't have a special announce (ie it was the only warning for that spell).