### PR TITLE
Update DBM-Core.toc

### DIFF
--- a/DBM-Core/DBM-Core.toc
+++ b/DBM-Core/DBM-Core.toc
@@ -16,8 +16,7 @@
 ## DefaultState: enabled
 ## Author: Barsoom, Bunny67, Zidras, DBM-Frostmourne contributors, original DBM team, fixes for sirus Stekolnyu, Waini, fxpw
 ## Version: 9.2.75
-
-X-Website: https://github.com/Waini4/DBM_For_Sirus
+## X-Website: https://github.com/Waini4/DBM_For_Sirus
 
 # Pre-pre-core loads
 AddFunctions.lua


### PR DESCRIPTION
X-Website не должен загружаться как ресурс

устранение ошибки из лога FrameXML.log:
```
8/2 12:02:49.059  ** Loading table of contents Interface\AddOns\DBM-Core\DBM-Core.toc
8/2 12:02:49.059  Couldn't open Interface\AddOns\DBM-Core\X-Website: https://github.com/Waini4/DBM_For_Sirus
```